### PR TITLE
Change references from notifywait_win32 to inotifywait_win32

### DIFF
--- a/lib/exfswatch.ex
+++ b/lib/exfswatch.ex
@@ -11,7 +11,7 @@ defmodule ExFSWatch do
   @backend (case :os.type() do
     {:unix,    :darwin} -> :fsevents
     {:unix,    :linux}  -> :inotifywait
-    {:"win32", :nt}     -> :"notifywait_win32"
+    {:"win32", :nt}     -> :"inotifywait_win32"
      _                  -> nil
   end)
 

--- a/lib/exfswatch/worker.ex
+++ b/lib/exfswatch/worker.ex
@@ -44,10 +44,10 @@ defmodule ExFSWatch.Worker do
               [:stream, :exit_status, {:line, 16384}, {:args, args}, {:cd, System.tmp_dir!}]
     )
   end
-  defp start_port(:"notifywait_win32", path) do
+  defp start_port(:"inotifywait_win32", path) do
     path = path |> format_path
     args = ['-m', '-r' | path]
-    Port.open({:spawn_executable, :"notifywait_win32".find_executable()},
+    Port.open({:spawn_executable, :"inotifywait_win32".find_executable()},
               [:stream, :exit_status, {:line, 16384}, {:args, args}, {:cd, System.tmp_dir!}]
     )
   end


### PR DESCRIPTION
The library you are depending on seems to have changed its name and has prepended the "i". This minor adjustment makes the library work for Windows without any further changes.
