### PR TITLE
update fs to dev version from github

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExFSWatch.Mixfile do
 
   def project do
     [ app: :exfswatch,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.0",
       deps: deps,
       description: "A file change watcher wrapper based on [fs](https://github.com/synrc/fs)",
@@ -19,7 +19,7 @@ defmodule ExFSWatch.Mixfile do
   end
 
   defp deps do
-    [ {:fs, "~> 0.9"} ]
+    [ {:fs, github: "synrc/fs", branch: "master"} ]
   end
 
   defp package do


### PR DESCRIPTION
Trying to update fs version.

Version in HEX has commented [this line](https://github.com/synrc/fs/blob/master/src/sys/inotifywait.erl#L21) and this breaks an ability to get `:create` event from filesystem.
