### PR TITLE
Fix fsevents support

### DIFF
--- a/lib/exfswatch/sys/inotifywait.ex
+++ b/lib/exfswatch/sys/inotifywait.ex
@@ -2,6 +2,7 @@ defmodule ExFSWatch.Sys.InotifyWait do
 
   def line_to_event(line) do
     line
+    |> to_string
     |> scan1
     |> scan2(line)
   end

--- a/lib/exfswatch/worker.ex
+++ b/lib/exfswatch/worker.ex
@@ -14,7 +14,7 @@ defmodule ExFSWatch.Worker do
   end
 
   def handle_info({port, {:data, {:eol, line}}}, %__MODULE__{port: port, backend: backend, module: module}=sd) do
-    {file_path, events} = backend(backend).line_to_event(to_string line)
+    {file_path, events} = backend(backend).line_to_event(line)
     module.callback(file_path |> to_string, events)
     {:noreply, sd}
   end

--- a/test/exfswatch_test.exs
+++ b/test/exfswatch_test.exs
@@ -1,7 +1,9 @@
 defmodule ExfswatchTest do
   use ExUnit.Case
+  import :fsevents
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  test "file modified" do
+    assert line_to_event('37425557\t0x00011400=[inodemetamod,modified]\t/one/two/file') ==
+      {'/one/two/file', [:inodemetamod, :modified]}
   end
 end


### PR DESCRIPTION
A previous commit (8a0f398) introduced a bug for the fsevents backend, which
expects a char list instead of a binary.
