### PR TITLE
Support optional listener args

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ Execute in iex
 iex > Monitor.start
 ```
 
+## Tweaking behaviour via listener extra arguments
+
+For each platform, you can pass extra arguments to the underlying listener process via the `listener_extra_args` option.
+
+Here is an example to get instant notifications on file changes for Mac OS X:
+
+```elixir
+use ExFSWatch, dirs: ["/tmp/fswatch"], listener_extra_args: "--latency=0.0"
+```
+
+See the [fs source](https://github.com/synrc/fs/tree/master/c_src) for more details.
+
 ## List Events from Backend
 
 ```shell

--- a/lib/exfswatch.ex
+++ b/lib/exfswatch.ex
@@ -1,9 +1,10 @@
 require Logger
 
 defmodule ExFSWatch do
-  defmacro __using__([dirs: dirs]) do
+  defmacro __using__(options) do
     quote do
-      def __dirs__, do: unquote(dirs)
+      def __dirs__, do: unquote(Keyword.fetch!(options, :dirs))
+      def __listener_extra_args__, do: unquote(Keyword.get(options, :listener_extra_args, ''))
       def start,    do: ExFSWatch.Supervisor.start_child __MODULE__
     end
   end


### PR DESCRIPTION
Today I wanted to have instant notifications on file save (I'm implementing a live music coding system in Elixir), and found out that I could achieve that with the `--latency=0.0` fs option on Mac.

Here is my attempt to wrap that (only tested on Mac) in a more generic support for exfswatch.

Example of use [in this gist](https://gist.github.com/thbar/1161034c641d32271419bf2e065cc071).
