### PR TITLE
Subscription Based API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,30 @@ defmodule Excellent.Mixfile do
 end
 ```
 
+
+### Subscription API
+
+You can spawn a worker and subscribe to events from it:
+
+```elixir
+{:ok, pid} = ExFSWatch.Worker.start_link(dirs: ["/path/to/some/files"])
+ExFSWatch.Worker.subscribe(pid)
+```
+
+The pid you subscribed from will now receive messages like
+
+```
+{:file_event, worker_pid, file_path, events}
+```
+and
+```
+{:file_event, worker_pid, :stop}
+```
+
+### Callback API
+
+You can also `use ExFSWatch` to define a module with a callback that will be called when filesystem events occur. This requires you to specify directories to watch at compile-time.
+
 write `lib/monitor.ex`
 
 ```elixir

--- a/lib/exfswatch/backend.ex
+++ b/lib/exfswatch/backend.ex
@@ -1,0 +1,6 @@
+defmodule ExFSWatch.Backend do
+  @callback find_executable() :: Sting.t
+  @callback start_port(String.t, keyword()) :: port()
+  @callback known_events() :: [atom()]
+  @callback line_to_event(String.t) :: {String.t, [atom()]}
+end

--- a/lib/exfswatch/backends/fsevents.ex
+++ b/lib/exfswatch/backends/fsevents.ex
@@ -1,7 +1,7 @@
 alias ExFSWatch.Utils
 
 defmodule ExFSWatch.Backends.Fsevents do
-
+  @behaviour ExFSWatch.Backend
   def find_executable do
     :code.priv_dir(:exfswatch) ++ '/mac_listener'
   end

--- a/lib/exfswatch/backends/inotify_wait.ex
+++ b/lib/exfswatch/backends/inotify_wait.ex
@@ -1,7 +1,7 @@
 alias ExFSWatch.Utils
 
 defmodule ExFSWatch.Backends.InotifyWait do
-
+  @behaviour ExFSWatch.Backend
   def find_executable do
     System.find_executable("sh") |> to_charlist
   end
@@ -29,7 +29,7 @@ defmodule ExFSWatch.Backends.InotifyWait do
     |> scan2(line)
   end
 
-  def scan1(line) do
+  defp scan1(line) do
     re = ~r/^(.*) ([A-Z_,]+) (.*)$/
     case Regex.scan re, line do
       [] -> {:error, :unknown}
@@ -38,7 +38,8 @@ defmodule ExFSWatch.Backends.InotifyWait do
     end
 
   end
-  def scan2({:error, :unknown}, line) do
+
+  defp scan2({:error, :unknown}, line) do
     re = ~r/^(.*) ([A-Z_,]+)$/
     case Regex.scan re, line do
       [] -> {:error, :unknown}
@@ -46,20 +47,21 @@ defmodule ExFSWatch.Backends.InotifyWait do
         {path, parse_events(events)}
     end
   end
-  def scan2(res, _), do: res
 
-  def parse_events(events) do
+  defp scan2(res, _), do: res
+
+  defp parse_events(events) do
     String.split(events, ",")
     |> Enum.map(&(convert_flag &1))
   end
 
-  def convert_flag("CREATE"),      do: :created
-  def convert_flag("DELETE"),      do: :deleted
-  def convert_flag("ISDIR"),       do: :isdir
-  def convert_flag("MODIFY"),      do: :modified
-  def convert_flag("CLOSE_WRITE"), do: :modified
-  def convert_flag("CLOSE"),       do: :closed
-  def convert_flag("MOVED_TO"),    do: :renamed
-  def convert_flag("ATTRIB"),      do: :attribute
-  def convert_flag(_),             do: :undefined
+  defp convert_flag("CREATE"),      do: :created
+  defp convert_flag("DELETE"),      do: :deleted
+  defp convert_flag("ISDIR"),       do: :isdir
+  defp convert_flag("MODIFY"),      do: :modified
+  defp convert_flag("CLOSE_WRITE"), do: :modified
+  defp convert_flag("CLOSE"),       do: :closed
+  defp convert_flag("MOVED_TO"),    do: :renamed
+  defp convert_flag("ATTRIB"),      do: :attribute
+  defp convert_flag(_),             do: :undefined
 end

--- a/lib/exfswatch/backends/inotify_wait_win32.ex
+++ b/lib/exfswatch/backends/inotify_wait_win32.ex
@@ -1,7 +1,7 @@
 alias ExFSWatch.Utils
 
 defmodule ExFSWatch.Backends.InotifyWaitWin32 do
-
+  @behaviour ExFSWatch.Backend
   @re :re.compile('^(.*\\\\.*) ([A-Z_,]+) (.*)$', [:unicode]) |> elem(1)
 
   def find_executable do

--- a/lib/exfswatch/backends/kqueue.ex
+++ b/lib/exfswatch/backends/kqueue.ex
@@ -1,7 +1,7 @@
 alias ExFSWatch.Utils
 
 defmodule ExFSWatch.Backends.Kqueue do
-
+  @behaviour ExFSWatch.Backend
   def known_events do
     [:created, :deleted, :renamed, :closed, :modified, :isdir, :undefined]
   end

--- a/lib/exfswatch/supervisor.ex
+++ b/lib/exfswatch/supervisor.ex
@@ -5,8 +5,8 @@ defmodule ExFSWatch.Supervisor do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  def start_child(module) do
-    Supervisor.start_child(__MODULE__, [module])
+  def start_child(args) do
+    Supervisor.start_child(__MODULE__, [args])
   end
 
   def init([]) do


### PR DESCRIPTION
Hey @falood, I wanted to get your feedback on this so far

1) I created a subscription-based API to ExFSWatch.Worker, so you can now subscribe to get messages from it.
2) I rewrote the Module based API to spawn a process that subscribes to events and calls the callbacks accordingly
3) I added a behaviour for ExFSWatch.Backend

Questions:
- Do we need a supervisor still? Should subscription clients get a supervised worker or just spawn_link it directly?
- Should we move `subscribe/1` and `spawn_link/1` to the main ExFSWatch module for a friendlier API?

TODO:
- [ ] Write tests for both subscription & module based api.