### PR TITLE
Use mac_listener and inotifywait.exe binaries if present on System PATH

### DIFF
--- a/lib/file_system/backends/fs_mac.ex
+++ b/lib/file_system/backends/fs_mac.ex
@@ -36,6 +36,8 @@ defmodule FileSystem.Backends.FSMac do
   use GenServer
   @behaviour FileSystem.Backend
 
+  @default_exec_file "mac_listener"
+
   def bootstrap do
     exec_file = executable_path()
     cond do
@@ -78,7 +80,7 @@ defmodule FileSystem.Backends.FSMac do
   end
 
   defp executable_path do
-    executable_path(:system_env) || executable_path(:config) || executable_path(:priv)
+    executable_path(:system_env) || executable_path(:config) || executable_path(:system_path) || executable_path(:priv)
   end
 
   defp executable_path(:config) do
@@ -95,13 +97,17 @@ defmodule FileSystem.Backends.FSMac do
     System.get_env("FILESYSTEM_FSMAC_EXECUTABLE_FILE")
   end
 
+  defp executable_path(:system_path) do
+    System.find_executable(@default_exec_file)
+  end
+
   defp executable_path(:priv) do
     case :code.priv_dir(:file_system) do
       {:error, _} ->
         Logger.error "`priv` dir for `:file_system` application is not avalible in current runtime, appoint executable file with `config.exs` or `FILESYSTEM_FSMAC_EXECUTABLE_FILE` env."
         nil
       dir when is_list(dir) ->
-        Path.join(dir, "mac_listener")
+        Path.join(dir, @default_exec_file)
     end
   end
 


### PR DESCRIPTION
Hi :) It is a work arround #34. Looks for the `mac_listener` and `inotifywait.exe` binaries at the system `PATH`. Using the `config.exs` is a great option, but forces me to specify a fixed location for the binaries while building the `escript`, using the system `PATH` adds flexibility to the binaries location. Thanks again!