### PR TITLE
Kill inotifywait when BEAM process exits and stop leaks

### DIFF
--- a/lib/file_system/backends/fs_inotify.ex
+++ b/lib/file_system/backends/fs_inotify.ex
@@ -106,9 +106,10 @@ defmodule FileSystem.Backends.FSInotify do
     {worker_pid, rest} = Keyword.pop(args, :worker_pid)
     case parse_options(rest) do
       {:ok, port_args} ->
+        bash_args = ['-c', to_charlist(executable_path()) ++ ' $0 $@ & PID=$!; read a; kill $PID']
         port = Port.open(
-          {:spawn_executable, to_charlist(executable_path())},
-          [:stream, :exit_status, {:line, 16384}, {:args, port_args}, {:cd, System.tmp_dir!()}]
+          {:spawn_executable, '/bin/sh'},
+          [:stream, :exit_status, {:line, 16384}, {:args, bash_args ++ port_args}, {:cd, System.tmp_dir!()}]
         )
         Process.link(port)
         Process.flag(:trap_exit, true)

--- a/test/backends/fs_inotify_test.exs
+++ b/test/backends/fs_inotify_test.exs
@@ -24,7 +24,7 @@ defmodule FileSystem.Backends.FSInotifyTest do
       assert {:ok, ['-e', 'modify', '-e', 'close_write', '-e', 'moved_to', '-e', 'create', '-e',
                     'delete', '-e', 'attrib', '--format', [37, 119, 1, 37, 101, 1, 37, 102],
                     '--quiet', '-m', '/tmp']} ==
-        parse_options(dirs: ["/tmp"], recursive: false, unsuppported: :options)
+        parse_options(dirs: ["/tmp"], recursive: false, unsupported: :options)
     end
   end
 


### PR DESCRIPTION
Exiting an Elixir app does not kill `inotifywait` and leaks processes. Errors start appearing after a few cycles.
```bash
$ mix phx.server
Failed to watch /app; upper limit on inotify watches reached!
Please increase the amount of inotify watches allowed per user via `/proc/sys/fs/inotify/max_user_watches'.
[info] Running SampleWeb.Endpoint with Cowboy using http://0.0.0.0:4000
```
In a Docker container, any attempt to exit will hang forever unless `inotifywait` is killed.

Wrapping `inotifywait` in a Bash hack (similar to `fs` package) solves this problem.
```bash
$ /bin/sh -c "inotifywait $0 $@ & PID=$!; read a; kill $PID" ... [args]
```