### PR TITLE
Fix ordering of arguments in handle_info :DOWN

### DIFF
--- a/lib/file_system/worker.ex
+++ b/lib/file_system/worker.ex
@@ -39,7 +39,7 @@ defmodule FileSystem.Worker do
     {:noreply, state}
   end
 
-  def handle_info({:DOWN, _pid, _, ref, _reason}, state) do
+  def handle_info({:DOWN, ref, _, _pid, _reason}, state) do
     subscribers = Map.drop(state.subscribers, [ref])
     {:noreply, %{state | subscribers: subscribers}}
   end


### PR DESCRIPTION
Due to incorrect ordering of parameters, subscribers were not being removed properly.

See [Process.monitor/1](https://hexdocs.pm/elixir/Process.html#monitor/1) for details on the ordering of these parameters.