### PR TITLE
Files being moved out of a directory trigger a "delete" event.

### DIFF
--- a/lib/file_system/backends/fs_inotify.ex
+++ b/lib/file_system/backends/fs_inotify.ex
@@ -74,8 +74,8 @@ defmodule FileSystem.Backends.FSInotify do
       {dirs, rest} ->
         format = ["%w", "%e", "%f"] |> Enum.join(@sep_char) |> to_charlist
         args = [
-          '-e', 'modify', '-e', 'close_write', '-e', 'moved_to', '-e', 'create',
-          '-e', 'delete', '-e', 'attrib', '--format', format, '--quiet', '-m', '-r'
+          '-e', 'modify', '-e', 'close_write', '-e', 'moved_to', '-e', 'moved_from',
+          '-e', 'create', '-e', 'delete', '-e', 'attrib', '--format', format, '--quiet', '-m', '-r'
           | dirs |> Enum.map(&Path.absname/1) |> Enum.map(&to_charlist/1)
         ]
         parse_options(rest, args)
@@ -150,6 +150,7 @@ defmodule FileSystem.Backends.FSInotify do
 
   defp convert_flag("CREATE"),      do: :created
   defp convert_flag("DELETE"),      do: :deleted
+  defp convert_flag("MOVE_FROM"),   do: :deleted
   defp convert_flag("ISDIR"),       do: :isdir
   defp convert_flag("MODIFY"),      do: :modified
   defp convert_flag("CLOSE_WRITE"), do: :modified

--- a/lib/file_system/backends/fs_inotify.ex
+++ b/lib/file_system/backends/fs_inotify.ex
@@ -150,7 +150,7 @@ defmodule FileSystem.Backends.FSInotify do
 
   defp convert_flag("CREATE"),      do: :created
   defp convert_flag("DELETE"),      do: :deleted
-  defp convert_flag("MOVE_FROM"),   do: :deleted
+  defp convert_flag("MOVED_FROM"),   do: :deleted
   defp convert_flag("ISDIR"),       do: :isdir
   defp convert_flag("MODIFY"),      do: :modified
   defp convert_flag("CLOSE_WRITE"), do: :modified

--- a/lib/file_system/backends/fs_inotify.ex
+++ b/lib/file_system/backends/fs_inotify.ex
@@ -150,7 +150,7 @@ defmodule FileSystem.Backends.FSInotify do
 
   defp convert_flag("CREATE"),      do: :created
   defp convert_flag("DELETE"),      do: :deleted
-  defp convert_flag("MOVED_FROM"),   do: :deleted
+  defp convert_flag("MOVED_FROM"),  do: :deleted
   defp convert_flag("ISDIR"),       do: :isdir
   defp convert_flag("MODIFY"),      do: :modified
   defp convert_flag("CLOSE_WRITE"), do: :modified

--- a/lib/file_system/backends/fs_inotify.ex
+++ b/lib/file_system/backends/fs_inotify.ex
@@ -41,7 +41,7 @@ defmodule FileSystem.Backends.FSInotify do
   end
 
   def known_events do
-    [:created, :deleted, :renamed, :closed, :modified, :isdir, :attribute, :undefined]
+    [:created, :deleted, :closed, :modified, :isdir, :attribute, :undefined]
   end
 
   defp executable_path do
@@ -149,13 +149,13 @@ defmodule FileSystem.Backends.FSInotify do
   end
 
   defp convert_flag("CREATE"),      do: :created
+  defp convert_flag("MOVED_TO"),    do: :created
   defp convert_flag("DELETE"),      do: :deleted
   defp convert_flag("MOVED_FROM"),  do: :deleted
   defp convert_flag("ISDIR"),       do: :isdir
   defp convert_flag("MODIFY"),      do: :modified
   defp convert_flag("CLOSE_WRITE"), do: :modified
   defp convert_flag("CLOSE"),       do: :closed
-  defp convert_flag("MOVED_TO"),    do: :renamed
   defp convert_flag("ATTRIB"),      do: :attribute
   defp convert_flag(_),             do: :undefined
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule FileSystem.Mixfile do
 
   def project do
     [ app: :file_system,
-      version: "0.2.2",
+      version: "0.2.3",
       elixir: "~> 1.3",
       deps: deps(),
       description: "A file system change watcher wrapper based on [fs](https://github.com/synrc/fs)",

--- a/test/backends/fs_inotify_test.exs
+++ b/test/backends/fs_inotify_test.exs
@@ -9,20 +9,20 @@ defmodule FileSystem.Backends.FSInotifyTest do
     end
 
     test "supported options" do
-      assert {:ok, ['-e', 'modify', '-e', 'close_write', '-e', 'moved_to', '-e', 'create', '-e',
-                    'delete', '-e', 'attrib', '--format', [37, 119, 1, 37, 101, 1, 37, 102],
+      assert {:ok, ['-e', 'modify', '-e', 'close_write', '-e', 'moved_to', '-e', 'moved_from', '-e', 'create',
+                    '-e', 'delete', '-e', 'attrib', '--format', [37, 119, 1, 37, 101, 1, 37, 102],
                     '--quiet', '-m', '-r', '/tmp']} ==
         parse_options(dirs: ["/tmp"], recursive: true)
 
-      assert {:ok, ['-e', 'modify', '-e', 'close_write', '-e', 'moved_to', '-e', 'create', '-e',
-                    'delete', '-e', 'attrib', '--format', [37, 119, 1, 37, 101, 1, 37, 102],
+      assert {:ok, ['-e', 'modify', '-e', 'close_write', '-e', 'moved_to', '-e', 'moved_from', '-e', 'create',
+                    '-e', 'delete', '-e', 'attrib', '--format', [37, 119, 1, 37, 101, 1, 37, 102],
                     '--quiet', '-m', '/tmp']} ==
         parse_options(dirs: ["/tmp"], recursive: false)
     end
 
     test "ignore unsupported options" do
-      assert {:ok, ['-e', 'modify', '-e', 'close_write', '-e', 'moved_to', '-e', 'create', '-e',
-                    'delete', '-e', 'attrib', '--format', [37, 119, 1, 37, 101, 1, 37, 102],
+      assert {:ok, ['-e', 'modify', '-e', 'close_write', '-e', 'moved_to', '-e', 'moved_from', '-e', 'create',
+                    '-e', 'delete', '-e', 'attrib', '--format', [37, 119, 1, 37, 101, 1, 37, 102],
                     '--quiet', '-m', '/tmp']} ==
         parse_options(dirs: ["/tmp"], recursive: false, unsupported: :options)
     end
@@ -42,7 +42,7 @@ defmodule FileSystem.Backends.FSInotifyTest do
     end
 
     test "dir moved to" do
-      assert {"/one/two/file", [:renamed]} ==
+      assert {"/one/two/file", [:created]} ==
         ~w|/one/two/ MOVED_TO file| |> to_port_line |> parse_line
     end
 


### PR DESCRIPTION
On most Linux machines, when "deleting" a file through a graphical file manager, the file is not actually deleted, but is moved to the trash. When using this library to watch my file system for the deletion of files, I'd delete a file through nautilus and would receive absolutely no notification from the watcher!

This is a super simple pull request that maps the `MOVED_FROM` event from inotifywatcher to the `:delete` event within `file_system`.