### PR TITLE
Limit split parts to allow equal characters in path

### DIFF
--- a/lib/file_system/backends/fs_mac.ex
+++ b/lib/file_system/backends/fs_mac.ex
@@ -170,7 +170,7 @@ defmodule FileSystem.Backends.FSMac do
   end
 
   def parse_line(line) do
-    [_, _, events, path] = line |> to_string |> String.split(["\t", "="])
+    [_, _, events, path] = line |> to_string |> String.split(["\t", "="], parts: 4)
     {path, events |> String.split(~w|[ , ]|, trim: true) |> Enum.map(&String.to_existing_atom/1)}
   end
 

--- a/test/backends/fs_mac_test.exs
+++ b/test/backends/fs_mac_test.exs
@@ -32,5 +32,10 @@ defmodule FileSystem.Backends.FSMacTest do
       assert {"/one two/file", [:inodemetamod, :modified]} ==
         parse_line('37425557\t0x00011400=[inodemetamod,modified]\t/one two/file')
     end
+
+    test "equal character in file" do
+      assert {"/one two/file=2", [:inodemetamod, :modified]} ==
+        parse_line('37425557\t0x00011400=[inodemetamod,modified]\t/one two/file=2')
+    end
   end
 end


### PR DESCRIPTION
Handle cases where directory/file names contains `=` and messes up the line handling when splitting.

Solves #48 