### PR TITLE
add a missing clause for parse_options function

### DIFF
--- a/lib/file_system/backends/fs_mac.ex
+++ b/lib/file_system/backends/fs_mac.ex
@@ -120,6 +120,9 @@ defmodule FileSystem.Backends.FSMac do
   defp parse_options([{:with_root, true} | t], result) do
     parse_options(t, ['--with-root' | result])
   end
+  defp parse_options([{:with_root, false} | t], result) do
+    parse_options(t, result)
+  end
   defp parse_options([{:with_root, value} | t], result) do
     Logger.error "unknown value `#{inspect value}` for with_root, ignore"
     parse_options(t, result)


### PR DESCRIPTION
Hi, @falood. It seems that a clause of `parse_options` function is missing, when the value of `with_root` option is `false`. This PR is to add this missing clause.