### PR TITLE
Use SIGKILL when killing inotifywait

### DIFF
--- a/lib/file_system/backends/fs_inotify.ex
+++ b/lib/file_system/backends/fs_inotify.ex
@@ -106,7 +106,7 @@ defmodule FileSystem.Backends.FSInotify do
     {worker_pid, rest} = Keyword.pop(args, :worker_pid)
     case parse_options(rest) do
       {:ok, port_args} ->
-        bash_args = ['-c', '#{executable_path()} $0 $@ & PID=$!; read a; kill $PID']
+        bash_args = ['-c', '#{executable_path()} $0 $@ & PID=$!; read a; kill -KILL $PID']
         port = Port.open(
           {:spawn_executable, '/bin/sh'},
           [:stream, :exit_status, {:line, 16384}, {:args, bash_args ++ port_args}, {:cd, System.tmp_dir!()}]


### PR DESCRIPTION
I've discovered this issue after opening https://github.com/phoenixframework/phoenix/issues/2942.

On some systems (e.g. Debian stretch and buster) inotifywait wasn't killed even after the fix introduced with #39. Adding -KILL to the kill command fixes this.