### PR TITLE
Inotify: allow to watch paths containing spaces

### DIFF
--- a/lib/file_system/backends/fs_inotify.ex
+++ b/lib/file_system/backends/fs_inotify.ex
@@ -101,7 +101,7 @@ defmodule FileSystem.Backends.FSInotify do
 
     case parse_options(rest) do
       {:ok, port_args} ->
-        bash_args = ['-c', '#{executable_path()} $0 $@ & PID=$!; read a; kill -KILL $PID']
+        bash_args = ['-c', '#{executable_path()} "$0" "$@" & PID=$!; read a; kill -KILL $PID']
 
         all_args =
           case :os.type() do


### PR DESCRIPTION
Before the fix, one would get an error message if the path to be watch contains a space.

This is now handeled properly.