### PR TITLE
Restore "renamed" flag on file rename event

### DIFF
--- a/lib/file_system/backends/fs_inotify.ex
+++ b/lib/file_system/backends/fs_inotify.ex
@@ -157,7 +157,7 @@ defmodule FileSystem.Backends.FSInotify do
   end
 
   defp convert_flag("CREATE"),      do: :created
-  defp convert_flag("MOVED_TO"),    do: :created
+  defp convert_flag("MOVED_TO"),    do: :renamed
   defp convert_flag("DELETE"),      do: :deleted
   defp convert_flag("MOVED_FROM"),  do: :deleted
   defp convert_flag("ISDIR"),       do: :isdir

--- a/lib/file_system/backends/fs_inotify.ex
+++ b/lib/file_system/backends/fs_inotify.ex
@@ -157,9 +157,9 @@ defmodule FileSystem.Backends.FSInotify do
   end
 
   defp convert_flag("CREATE"),      do: :created
-  defp convert_flag("MOVED_TO"),    do: :renamed
+  defp convert_flag("MOVED_TO"),    do: :moved_to
   defp convert_flag("DELETE"),      do: :deleted
-  defp convert_flag("MOVED_FROM"),  do: :deleted
+  defp convert_flag("MOVED_FROM"),  do: :moved_from
   defp convert_flag("ISDIR"),       do: :isdir
   defp convert_flag("MODIFY"),      do: :modified
   defp convert_flag("CLOSE_WRITE"), do: :modified

--- a/test/backends/fs_inotify_test.exs
+++ b/test/backends/fs_inotify_test.exs
@@ -42,12 +42,12 @@ defmodule FileSystem.Backends.FSInotifyTest do
     end
 
     test "dir moved to" do
-      assert {"/one/two/file", [:renamed]} ==
+      assert {"/one/two/file", [:moved_to]} ==
         ~w|/one/two/ MOVED_TO file| |> to_port_line |> parse_line
     end
 
     test "dir moved from" do
-      assert {"/one/two/file", [:deleted]} ==
+      assert {"/one/two/file", [:moved_from]} ==
         ~w|/one/two/ MOVED_FROM file| |> to_port_line |> parse_line
     end
 

--- a/test/backends/fs_inotify_test.exs
+++ b/test/backends/fs_inotify_test.exs
@@ -42,8 +42,13 @@ defmodule FileSystem.Backends.FSInotifyTest do
     end
 
     test "dir moved to" do
-      assert {"/one/two/file", [:created]} ==
+      assert {"/one/two/file", [:renamed]} ==
         ~w|/one/two/ MOVED_TO file| |> to_port_line |> parse_line
+    end
+
+    test "dir moved from" do
+      assert {"/one/two/file", [:deleted]} ==
+        ~w|/one/two/ MOVED_FROM file| |> to_port_line |> parse_line
     end
 
     test "dir is_dir create" do


### PR DESCRIPTION
Related to Issue #67 
Don't really sure it is what you want, since a recent patch changed exactly this behavior.
