### PR TITLE
Better character handling

### DIFF
--- a/lib/file_system/backends/fs_inotify.ex
+++ b/lib/file_system/backends/fs_inotify.ex
@@ -125,7 +125,7 @@ defmodule FileSystem.Backends.FSInotify do
 
         port = Port.open(
           {:spawn_executable, '/bin/sh'},
-          [:stream, :exit_status, {:line, 16384}, {:args, all_args}, {:cd, System.tmp_dir!()}]
+          [:binary, :stream, :exit_status, {:line, 16384}, {:args, all_args}, {:cd, System.tmp_dir!()}]
         )
 
         Process.link(port)
@@ -160,7 +160,7 @@ defmodule FileSystem.Backends.FSInotify do
 
   def parse_line(line) do
     {path, flags} =
-      case line |> to_string |> String.split(@sep_char, trim: true) do
+      case String.split(line, @sep_char, trim: true) do
         [dir, flags, file] -> {Path.join(dir, file), flags}
         [path, flags]      -> {path, flags}
       end

--- a/test/backends/fs_inotify_test.exs
+++ b/test/backends/fs_inotify_test.exs
@@ -34,7 +34,7 @@ defmodule FileSystem.Backends.FSInotifyTest do
   end
 
   describe "port line parse test" do
-    defp to_port_line(list), do: list |> Enum.join(<<1>>) |> to_charlist
+    defp to_port_line(list), do: list |> Enum.join(<<1>>)
 
     test "dir write close" do
       assert {"/one/two/file", [:modified, :closed]} ==


### PR DESCRIPTION
Enabling the `:binary` option when starting the inotifywait port let's us handle filenames like **The Hitchhiker’s guide to the galaxy** which would otherwise get messed up because of the **’** .