### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10
 
 ## Usage
 
-Put `:file_system` in the `deps` and `application` part of your `mix.exs`:
+Add `file_system` to the `deps` of your mix.exs
 
 ``` elixir
-defmodule Excellent.Mixfile do
+defmodule MyApp.Mixfile do
   use Mix.Project
 
   def project do


### PR DESCRIPTION
- Don't mention `application` because no change is needed in that part of mix.exs
- Also use `MyApp` as the application prefix since that is the common idiom in Elixir