### PR TITLE
fix: apply `CFLAGS` and `LDFLAGS` during build step

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -57,8 +57,11 @@ defmodule FileSystem.Mixfile do
     if Mix.Utils.stale?(Path.wildcard(source), [target]) do
       Logger.info("Compiling file system watcher for Mac...")
 
+      cflags = System.get_env("CFLAGS", "")
+      ldflags = System.get_env("LDFLAGS", "")
+
       cmd =
-        "clang -framework CoreFoundation -framework CoreServices -Wno-deprecated-declarations #{
+        "clang #{cflags} #{ldflags} -framework CoreFoundation -framework CoreServices -Wno-deprecated-declarations #{
           source
         } -o #{target}"
 


### PR DESCRIPTION
This is required for some non-standard environments where user may want to configure some compilation flags (for example `-iframeworks`).