### PR TITLE
Set minimum supported Elixir version to 1.11.x

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.12.3
-              otp: 23.3
+              elixir: 1.11.4
+              otp: 22.3
           - pair:
               elixir: 1.15.7
               otp: 26.1
@@ -31,7 +31,7 @@ jobs:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: mix deps.get
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.12.3
-              otp: 23.3
+              elixir: 1.11.4
+              otp: 22.3
           - pair:
               elixir: 1.15.7
               otp: 26.1
@@ -28,7 +28,7 @@ jobs:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: mix deps.get
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule FileSystem.MixProject do
     [
       app: :file_system,
       version: @version,
-      elixir: "~> 1.3",
+      elixir: "~> 1.11",
       deps: deps(),
       description: description(),
       package: package(),


### PR DESCRIPTION
The minimum supported Elixir version with security patches right now (latest greatest stable version is 1.15.x) is 1.11.x.
      
See https://hexdocs.pm/elixir/1.15.7/compatibility-and-deprecations.html
