### PR TITLE
Adding {:unix, :sunos} support

### DIFF
--- a/lib/file_system/backend.ex
+++ b/lib/file_system/backend.ex
@@ -37,6 +37,7 @@ defmodule FileSystem.Backend do
       {:unix, :linux} -> :fs_inotify
       {:unix, :freebsd} -> :fs_inotify
       {:unix, :openbsd} -> :fs_inotify
+      {:unix, :sunos} -> :fs_poll
       {:win32, :nt} -> :fs_windows
       system -> {:unsupported_system, system}
     end

--- a/lib/file_system/backends/fs_poll.ex
+++ b/lib/file_system/backends/fs_poll.ex
@@ -22,7 +22,7 @@ defmodule FileSystem.Backends.FSPoll do
   def bootstrap, do: :ok
 
   def supported_systems do
-    [{:unix, :linux}, {:unix, :freebsd}, {:unix, :openbsd}, {:unix, :darwin}, {:win32, :nt}]
+    [{:unix, :linux}, {:unix, :freebsd}, {:unix, :openbsd}, {:unix, :darwin}, {:unix, :sunos}, {:win32, :nt}]
   end
 
   def known_events do


### PR DESCRIPTION
fs_poll should be available in the {:unix, :sunos} environment.