### PR TITLE
Fixes compilation on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ On MacOS 10.14, to compile `mac_listener`, run:
 open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
 ```
 
+On newer versions this file doesn't exist. But it still should work just fine as long as you have xcode installed.
+
 ## Usage
 
 Add `file_system` to the `deps` of your mix.exs

--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,7 @@ defmodule FileSystem.MixProject do
       ldflags = System.get_env("LDFLAGS", "")
 
       cmd =
-        "clang #{cflags} #{ldflags} -framework CoreFoundation -framework CoreServices -Wno-deprecated-declarations #{source} -o #{target}"
+        "xcrun -r clang #{cflags} #{ldflags} -framework CoreFoundation -framework CoreServices -Wno-deprecated-declarations #{source} -o #{target}"
 
       if Mix.shell().cmd(cmd) > 0 do
         Logger.error(


### PR DESCRIPTION
Advice in the `README` doesn't really work on modern Macs. What works thou is running xcode's version of `clang`.