### PR TITLE
Fix typo

### DIFF
--- a/lib/file_system/backends/fs_mac.ex
+++ b/lib/file_system/backends/fs_mac.ex
@@ -165,16 +165,16 @@ defmodule FileSystem.Backends.FSMac do
     parse_options(t, result)
   end
 
-  defp parse_options([{:with_root, true} | t], result) do
-    parse_options(t, [~c"--with-root" | result])
+  defp parse_options([{:watch_root, true} | t], result) do
+    parse_options(t, [~c"--watch-root" | result])
   end
 
-  defp parse_options([{:with_root, false} | t], result) do
+  defp parse_options([{:watch_root, false} | t], result) do
     parse_options(t, result)
   end
 
-  defp parse_options([{:with_root, value} | t], result) do
-    Logger.error("unknown value `#{inspect(value)}` for with_root, ignore")
+  defp parse_options([{:watch_root, value} | t], result) do
+    Logger.error("unknown value `#{inspect(value)}` for watch_root, ignore")
     parse_options(t, result)
   end
 

--- a/test/backends/fs_mac_test.exs
+++ b/test/backends/fs_mac_test.exs
@@ -12,8 +12,8 @@ defmodule FileSystem.Backends.FSMacTest do
     end
 
     test "supported options" do
-      assert {:ok, [~c"--with-root", ~c"--no-defer", ~c"--latency=0.0", ~c"-F", ~c"/tmp"]} ==
-               parse_options(dirs: ["/tmp"], latency: 0, no_defer: true, with_root: true)
+      assert {:ok, [~c"--watch-root", ~c"--no-defer", ~c"--latency=0.0", ~c"-F", ~c"/tmp"]} ==
+               parse_options(dirs: ["/tmp"], latency: 0, no_defer: true, watch_root: true)
 
       assert {:ok, [~c"--no-defer", ~c"--latency=1.1", ~c"-F", ~c"/tmp1", ~c"/tmp2"]} ==
                parse_options(dirs: ["/tmp1", "/tmp2"], latency: 1.1, no_defer: true)

--- a/test/file_system_test.exs
+++ b/test/file_system_test.exs
@@ -7,7 +7,7 @@ defmodule FileSystemTest do
     tmp_dir = mktemp_d!()
     on_exit(fn -> File.rm_rf!(tmp_dir) end)
 
-    {:ok, pid} = FileSystem.start_link(dirs: [tmp_dir])
+    {:ok, pid} = FileSystem.start_link(dirs: [tmp_dir], watch_root: true)
     FileSystem.subscribe(pid)
 
     :timer.sleep(200)


### PR DESCRIPTION
Fix  typo
```shell
....................mac_listener: unrecognized option `--with-root'

16:15:30.176 [error] GenServer #PID<0.265.0> terminating
** (MatchError) no match of right hand side value: ["VXZ 1.0"]
    (file_system 1.1.0) lib/file_system/backends/fs_mac.ex:231: FileSystem.Backends.FSMac.parse_line/1
    (file_system 1.1.0) lib/file_system/backends/fs_mac.ex:211: FileSystem.Backends.FSMac.handle_info/2
    (stdlib 6.0) gen_server.erl:2173: :gen_server.try_handle_info/3
    (stdlib 6.0) gen_server.erl:2261: :gen_server.handle_msg/6
    (stdlib 6.0) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
Last message: {#Port<0.12>, {:data, {:eol, ~c"VXZ 1.0"}}}
State: %{port: #Port<0.12>, worker_pid: #PID<0.264.0>}
```
Changed with-root to watch-root