### PR TITLE
Update CI workflows for latest Elixir and OTP versions

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.11.x
-              otp: 22.x
+              elixir: "1.11"
+              otp: "22"
           - pair:
-              elixir: 1.17.x
-              otp: 27.x
+              elixir: "1.18"
+              otp: "28"
             lint: lint
     steps:
       - name: Install inotify-tools
@@ -31,7 +31,7 @@ jobs:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - run: mix deps.get
 

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -24,7 +24,7 @@ jobs:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: brew install elixir
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - run: mix deps.get
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: windows-latest
+    runs-on: win22
     env:
       MIX_ENV: test
     strategy:
@@ -16,14 +16,17 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.11.x
-              otp: 22.x
+              elixir: "1.11"
+              otp: "22"
           - pair:
-              elixir: 1.17.x
-              otp: 27.x
+              elixir: "1.17"
+              otp: "27"
           - pair:
-              elixir: 1.18.x
-              otp: 27.x
+              elixir: "1.18"
+              otp: "27"
+          - pair:
+              elixir: "1.18"
+              otp: "28"
 
     steps:
       - uses: erlef/setup-beam@v1
@@ -31,7 +34,7 @@ jobs:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - run: mix deps.get
 


### PR DESCRIPTION
This commit updates the continuous integration (CI) workflows for GNU/Linux, macOS, and Windows.

List of changes:
- bump actions/checkout to version 5 across all three workflows
- use strings as versions, not number
- include Elixir (1.18) and OTP (28) to test matrix